### PR TITLE
Add php-sodium

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN yum -y install \
         php72-php-pdo \
         php72-php-process \
         php72-php-zip \
+        php72-php-sodium \
         php72-php-pecl-mailparse && \
     yum clean all
 


### PR DESCRIPTION
[request #12278](https://tuleap.net/plugins/tracker/?aid=12278): Tuleap cryptography API should work out of box on PHP 7.2 with php-sodium.


Must be merged after [gerrit #12630](https://gerrit.tuleap.net/#/c/tuleap/+/12630/).