### PR TITLE
Add mysqlnd package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN yum install -y epel-release \
         php73-php-soap \
         php73-php-ldap \
         php73-php-intl \
+        php73-php-mysqlnd \
         php73-php-pecl-mailparse \
         php73-php-pecl-redis \
         php73-php-pecl-pcov \


### PR DESCRIPTION
This package is not directly needed by the unit tests at the moment but is needed for SA tools as they need to know and interpret the whole codebase.

Part of request #17910: Compatibility with Composer 2