### PR TITLE
Use 'tuleap-git' instad of a legacy Git version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM centos:7
 
 COPY remi-safe.repo /etc/yum.repos.d/
+COPY Tuleap.repo /etc/yum.repos.d/
 
 RUN yum install -y epel-release \
     centos-release-scl && \
     yum -y install \
         make \
-        git \
-        rh-git218 \
+        tuleap-git-bin \
+        openssh \
         php81-php-cli \
         php81-php-xml \
         php81-php-mbstring \

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2014-2017 Enalean
+Copyright (c) 2014-Present Enalean
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Tuleap.repo
+++ b/Tuleap.repo
@@ -1,0 +1,7 @@
+[Tuleap]
+name=Tuleap
+baseurl=https://ci.tuleap.net/yum/tuleap/rhel/7/dev/$basearch
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://ci.tuleap.net/yum/tuleap/gpg.key


### PR DESCRIPTION
Part of [request #29230](https://tuleap.net/plugins/tracker/?aid=29230): Drop remaining support of rh-git218

To be merged **after** https://gerrit.tuleap.net/c/tuleap/+/27625