### PR TITLE
ci: Drop Dependabot config for PHP 8.3 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,3 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-- package-ecosystem: "github-actions"
-  directory: "/"
-  target-branch: "c7-php83"
-  schedule:
-    interval: daily


### PR DESCRIPTION
Everything is built from `main` now