### PR TITLE
chore: Stop building PHP 8.3 image

### DIFF
--- a/.github/workflows/Build_And_Publish_Docker_Images.yml
+++ b/.github/workflows/Build_And_Publish_Docker_Images.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os_base: ["el9"]
-        php_base: ["php82", "php83", "php84"]
+        php_base: ["php82", "php84"]
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/Build_Docker_Image_PR.yml
+++ b/.github/workflows/Build_Docker_Image_PR.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os_base: ["el9"]
-        php_base: ["php82", "php83"]
+        php_base: ["php82", "php84"]
     runs-on: ubuntu-24.04
     permissions:
       contents: read


### PR DESCRIPTION
We are not going to need it anymore.
PHP 8.4 base images are now also tested on PR.

Part of request #41110 Run Tuleap with PHP 8.4